### PR TITLE
Fix private config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # org the new repo will be in. GitHub automatically applies the correct version.
 
 # Uncomment the appropriate team line to automatically tag the owning team on PRs
-# * @cyberark/community-and-integrations-team @conjurinc/community-and-integrations-team @conjurdemos/community-and-integrations-team
+* @cyberark/community-and-integrations-team @conjurinc/community-and-integrations-team @conjurdemos/community-and-integrations-team
 # * @cyberark/conjur-core-team @conjurinc/conjur-core-team @conjurdemos/conjur-core-team
 
 # Changes to .trivyignore require Security Architect approval

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test/
+.idea/

--- a/pkg/trace/console-tracer-provider.go
+++ b/pkg/trace/console-tracer-provider.go
@@ -48,16 +48,16 @@ func newConsoleTracerProvider(config TracerProviderConfig) (TracerProvider, erro
 		// Record information about this application in a Resource.
 		tracesdk.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(config.tracerService),
-			attribute.String("environment", config.tracerEnvironment),
-			attribute.Int64("ID", config.tracerID),
+			semconv.ServiceNameKey.String(config.TracerService),
+			attribute.String("environment", config.TracerEnvironment),
+			attribute.Int64("ID", config.TracerID),
 		)),
 	)
 	tp := consoleTracerProvider{
 		providerSDK:   providerSDK,
 		tempFilePath:  tempFile.Name(),
-		consoleWriter: config.consoleWriter,
-		tracerName:    config.tracerName,
+		consoleWriter: config.ConsoleWriter,
+		tracerName:    config.TracerName,
 	}
 	return &tp, nil
 }

--- a/pkg/trace/jaeger-tracer-provider.go
+++ b/pkg/trace/jaeger-tracer-provider.go
@@ -21,7 +21,7 @@ type jaegerTracerProvider struct {
 
 func newJaegerTracerProvider(config TracerProviderConfig) (TracerProvider, error) {
 	// Create the Jaeger exporter
-	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(config.collectorURL)))
+	exp, err := jaeger.New(jaeger.WithCollectorEndpoint(jaeger.WithEndpoint(config.CollectorURL)))
 	if err != nil {
 		return nil, err
 	}
@@ -31,14 +31,14 @@ func newJaegerTracerProvider(config TracerProviderConfig) (TracerProvider, error
 		// Record information about this application in a Resource.
 		tracesdk.WithResource(resource.NewWithAttributes(
 			semconv.SchemaURL,
-			semconv.ServiceNameKey.String(config.tracerService),
-			attribute.String("environment", config.tracerEnvironment),
-			attribute.Int64("ID", config.tracerID),
+			semconv.ServiceNameKey.String(config.TracerService),
+			attribute.String("environment", config.TracerEnvironment),
+			attribute.Int64("ID", config.TracerID),
 		)),
 	)
 	tp := jaegerTracerProvider{
 		providerSDK: providerSDK,
-		tracerName:  config.tracerName,
+		tracerName:  config.TracerName,
 	}
 	return &tp, nil
 }

--- a/pkg/trace/tracer-provider.go
+++ b/pkg/trace/tracer-provider.go
@@ -27,17 +27,17 @@ const (
 
 type TracerProviderConfig struct {
 	// Name of the tracer
-	tracerName string
+	TracerName string
 	// Service to be traced
-	tracerService string
+	TracerService string
 	// Execution environment such as "production" or "development"
-	tracerEnvironment string
+	TracerEnvironment string
 	// Unique ID of the tracer
-	tracerID int64
+	TracerID int64
 	// URL of the collector when using Jaeger
-	collectorURL string
+	CollectorURL string
 	// Writer to use for the console tracer
-	consoleWriter io.Writer
+	ConsoleWriter io.Writer
 }
 
 // TracerProvider provides access to Tracers, which in turn allow for creation

--- a/pkg/trace/tracer_test.go
+++ b/pkg/trace/tracer_test.go
@@ -70,8 +70,8 @@ func TestTracer(t *testing.T) {
 			ctx := context.Background()
 
 			tp, err := NewTracerProvider(tc.providerType, false, TracerProviderConfig{
-				collectorURL:  tc.collectorUrl,
-				consoleWriter: output,
+				CollectorURL:  tc.collectorUrl,
+				ConsoleWriter: output,
 			})
 			assert.NoError(t, err)
 			tracer := tp.Tracer(tc.name)


### PR DESCRIPTION
Make config params public so they can be used by consuming applications. It was a mistake to have them private in the first place.
Should be merged after #2 