### PR TITLE
Build module in docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 test/
 .idea/
+build_ca_certificate/
+VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+#=============== Build Container ===================
+FROM golang:1.17-stretch
+
+ARG GIT_COMMIT_SHORT="dev"
+ARG KUBECTL_VERSION=1.23.0
+
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+RUN mkdir -p /work
+WORKDIR /work
+
+ENV GOOS=linux \
+    GOARCH=amd64 \
+    CGO_ENABLED=0
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+# source files
+COPY pkg ./pkg
+
+# The `gitCommitShort` override is there to provide the git commit information in the final
+# binary.
+RUN go build \
+    -ldflags="-X github.com/cyberark/conjur-opentelemetry-tracer/pkg/version.gitCommitShort=$GIT_COMMIT_SHORT" \
+    -o cyberark-conjur-opentelemetry-tracer \
+    ./pkg/trace

--- a/bin/build
+++ b/bin/build
@@ -1,5 +1,26 @@
-#!/usr/bin/env bash
+#!/bin/bash -e
+#
+# Build Conjur OpenTelemetry Tracer
+# usage: ./bin/build
+set -ex
 
-set -euo pipefail
+cd "$(dirname "${0}")"
+. ./build_utils
+cd ..
 
-go build ./...
+readonly IMAGE_NAME="conjur-opentelemetry-tracer"
+
+function main() {
+  retrieve_cyberark_ca_cert
+  build_docker_image
+}
+
+function build_docker_image() {
+  docker build \
+    --build-arg "GIT_COMMIT_SHORT=$(git_commit_short)" \
+    -t "${IMAGE_NAME}:latest" \
+    -t "${IMAGE_NAME}:$(full_version_tag)" \
+    .
+}
+
+main

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -euo pipefail
+
+####
+# Functions to generate version numbers for this project
+####
+
+# Set up VERSION file for local development
+if [ ! -f "VERSION" ]; then
+  echo -n "0.0.dev" > VERSION
+fi
+readonly VERSION_FILE="$(<VERSION)"
+
+function git_version() {
+  echo "$VERSION_FILE"
+}
+
+function git_commit_short() {
+  git rev-parse --short=8 HEAD
+}
+
+function full_version_tag() {
+  echo "$(git_version)-$(git_commit_short)"
+}
+
+
+function retrieve_cyberark_ca_cert() {
+  # On CyberArk dev laptops, golang module dependencies are downloaded with a
+  # corporate proxy in the middle. For these connections to succeed we need to
+  # configure the proxy CA certificate in build containers.
+  #
+  # To allow this script to also work on non-CyberArk laptops where the CA
+  # certificate is not available, we update container certificates based on
+  # a (potentially empty) certificate directory, rather than relying on the
+  # CA file itself.
+  mkdir -p "$(repo_root)/build_ca_certificate"
+
+  # Only attempt to extract the certificate if the security
+  # command is available.
+  #
+  # The certificate file must have the .crt extension to be imported
+  # by `update-ca-certificates`.
+  if command -v security &> /dev/null
+  then
+    security find-certificate \
+      -a -c "CyberArk Enterprise Root CA" \
+      -p > build_ca_certificate/cyberark_root.crt
+  fi
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+}

--- a/bin/test
+++ b/bin/test
@@ -31,7 +31,7 @@ echo "Creating junit report..."
 
 docker run --rm \
   -v $PWD/test:/test \
-  conjur-authn-k8s-client-junit:latest \
+  conjur-opentelemetry-tracer-junit:latest \
   bash -exc "
     cat ./junit.output | go-junit-report > ./junit.xml
   "

--- a/pkg/trace/version.go
+++ b/pkg/trace/version.go
@@ -1,0 +1,3 @@
+package trace
+
+const Version = "0.0.1"


### PR DESCRIPTION
This allows the build to complete in Jenkins where the 'go' binary isn't available.