### PR TITLE
Add replace for gopkg.in/yaml.v3 to ensure we use 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Basic functionality [cyberark/conjur-opentelemetry-tracer#1](https://github.com/cyberark/conjur-opentelemetry-tracer/pull/1)
 
 ### Changed
+- Added replace for gopkg.in/yaml.v3 to ensure we use latest version in dep tree
+  [cyberark/conjur-opentelemetry-tracer#6](https://github.com/cyberark/conjur-opentelemetry-tracer/pull/6)
 - Updated go dependencies to latest versions (github.com/stretchr/testify -> 1.7.2, 
   go.opentelemetry.io/otel/* -> 1.7.0)
   [cyberark/conjur-opentelemetry-tracer#5](https://github.com/cyberark/conjur-opentelemetry-tracer/pull/5)

--- a/go.mod
+++ b/go.mod
@@ -19,3 +19,5 @@ require (
 	golang.org/x/sys v0.0.0-20220111092808-5a964db01320 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c => gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,5 @@ golang.org/x/sys v0.0.0-20220111092808-5a964db01320/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Remove gopkg.in/yaml.v3 versions prior to 3.0.1 from consideration in dependency tree.

### Implemented Changes

Added replace to go.mod to force indirect dependencies to use 3.0.1.