### PR TITLE
Fix false positive tests in test stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,8 +69,12 @@ pipeline {
     stage('Test') {
       steps {
         sh './bin/test'
-
-        junit 'test/junit.xml'
+      }
+      post {
+        always {
+          sh './bin/coverage'
+          junit 'test/junit.xml'
+        }
       }
     }
   

--- a/bin/coverage
+++ b/bin/coverage
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -eox pipefail
+
+junit_output_file="test/junit.output"
+
+rm -f junit.xml
+
+echo "Building junit image..."
+
+docker build -f Dockerfile.junit -t conjur-opentelemetry-tracer-junit:latest .
+
+echo "Creating junit report..."
+
+docker run --rm \
+  -v $PWD/test:/test \
+  conjur-opentelemetry-tracer-junit:latest \
+  bash -exc "
+    cat ./junit.output | go-junit-report > ./junit.xml
+  "

--- a/bin/test
+++ b/bin/test
@@ -14,24 +14,7 @@ echo "Building unit test image..."
 docker build -f Dockerfile.test -t conjur-opentelemetry-tracer-test-runner:latest .
 
 echo "Running unit tests..."
-set +e
   docker run --rm -t conjur-opentelemetry-tracer-test-runner:latest \
              ./pkg/... \
              | tee -a "$junit_output_file"
   echo "Unit test exit status: $?"
-set -e
-
-rm -f junit.xml
-
-echo "Building junit image..."
-
-docker build -f Dockerfile.junit -t conjur-opentelemetry-tracer-junit:latest .
-
-echo "Creating junit report..."
-
-docker run --rm \
-  -v $PWD/test:/test \
-  conjur-opentelemetry-tracer-junit:latest \
-  bash -exc "
-    cat ./junit.output | go-junit-report > ./junit.xml
-  "


### PR DESCRIPTION
### Desired Outcome

Several of our CI pipelines follow [this pattern](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/bin/test_unit#L31) where the script that runs unit tests sets +e to prevent unit test failure from stopping the script from running. I believe this was done to ensure that the junit tests would run even if the tests failed, but it's having the unfortunate side effect of showing the unit testing phase as green in Jenkins when a unit test fails, making it a bit unclear what's going on.

### Implemented Changes

Break the junit logic into a separate script that can be run independently from the unit tests in a "post-always" block in the Jenkinsfile and return the error code when unit test(s) fail.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
